### PR TITLE
Uploading a file with % in the name fails.

### DIFF
--- a/lib/multipartupload.js
+++ b/lib/multipartupload.js
@@ -127,6 +127,14 @@ MultiPartUpload.prototype._initiate = function(callback) {
     parse.xmlResponse(req, function(err, body) {
 
         if (err) return callback(err);
+        
+        if (body === null) {
+          return callback((function (){
+            var err = new Error('Unexpected response from AWS.');
+            return err;
+          })());
+        }
+        
         if (!body.UploadId) {
           return callback((function (){
             var err = new Error('Unexpected response from AWS:' + util.inspect(body, false, null));


### PR DESCRIPTION
Uploading a file with a % in the name generates an unhandled exception. This fix prevents the exception from happening. Does not fix the response body being returned as null.
